### PR TITLE
Add basic Next.js app with Prisma auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # EntraDa
 
-NEXT con un backeend con una manejo simple de login logout recover password  y signup,  Usara una base de datos postgres Prisma para el manejo de modelos y todo en typescript 
+Simple Next.js app with authentication (signup, login, logout, password recovery) using Prisma and PostgreSQL. Everything is written in TypeScript.
+
+## Scripts
+
+- `npm run dev` – start development server
+- `npm run build` – build application
+- `npm start` – start production server
+
+Set a `DATABASE_URL` environment variable pointing to your PostgreSQL instance before running Prisma commands.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "entrada",
+  "version": "1.0.0",
+  "description": "Simple Next.js app with auth and Prisma",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests\" && exit 0"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@prisma/client": "latest",
+    "prisma": "latest",
+    "bcryptjs": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "@types/node": "latest"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,19 @@
+// Prisma schema for User model
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id            Int      @id @default(autoincrement())
+  email         String   @unique
+  passwordHash  String
+  resetToken    String?  @unique
+  resetTokenExp DateTime?
+  createdAt     DateTime @default(now())
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,9 @@
+import bcrypt from 'bcryptjs';
+
+export function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, 10);
+}
+
+export function verifyPassword(password: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(password, hash);
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({ log: ['query'] });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+import { verifyPassword } from '../../../lib/auth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const { email, password } = req.body;
+  if (!email || !password) return res.status(400).json({ message: 'Email and password required' });
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+
+  const isValid = await verifyPassword(password, user.passwordHash);
+  if (!isValid) return res.status(401).json({ message: 'Invalid credentials' });
+
+  res.setHeader('Set-Cookie', `session=${user.id}; HttpOnly; Path=/; Max-Age=3600`);
+  return res.status(200).json({ id: user.id, email: user.email });
+}

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Set-Cookie', 'session=; HttpOnly; Path=/; Max-Age=0');
+  res.status(200).json({ message: 'Logged out' });
+}

--- a/src/pages/api/auth/recover.ts
+++ b/src/pages/api/auth/recover.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+import { hashPassword } from '../../../lib/auth';
+import crypto from 'crypto';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { email } = req.body;
+    if (!email) return res.status(400).json({ message: 'Email required' });
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) return res.status(200).json({ message: 'If account exists, email sent' });
+
+    const token = crypto.randomBytes(32).toString('hex');
+    const resetTokenExp = new Date(Date.now() + 3600 * 1000);
+    await prisma.user.update({
+      where: { email },
+      data: { resetToken: token, resetTokenExp }
+    });
+
+    return res.status(200).json({ message: 'Reset token generated', token });
+  } else if (req.method === 'PUT') {
+    const { token, password } = req.body;
+    if (!token || !password) return res.status(400).json({ message: 'Token and password required' });
+
+    const user = await prisma.user.findFirst({
+      where: { resetToken: token, resetTokenExp: { gt: new Date() } }
+    });
+    if (!user) return res.status(400).json({ message: 'Invalid token' });
+
+    const passwordHash = await hashPassword(password);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { passwordHash, resetToken: null, resetTokenExp: null }
+    });
+    return res.status(200).json({ message: 'Password updated' });
+  } else {
+    return res.status(405).end();
+  }
+}

--- a/src/pages/api/auth/signup.ts
+++ b/src/pages/api/auth/signup.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+import { hashPassword } from '../../../lib/auth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const { email, password } = req.body;
+  if (!email || !password) return res.status(400).json({ message: 'Email and password required' });
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) return res.status(409).json({ message: 'User already exists' });
+
+  const passwordHash = await hashPassword(password);
+
+  const user = await prisma.user.create({ data: { email, passwordHash } });
+
+  return res.status(201).json({ id: user.id, email: user.email });
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Bienvenido</h1>
+      <nav>
+        <ul>
+          <li><Link href="/login">Login</Link></li>
+          <li><Link href="/signup">Signup</Link></li>
+          <li><Link href="/recover">Recover Password</Link></li>
+        </ul>
+      </nav>
+    </div>
+  );
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    setMessage(res.ok ? 'Logged in' : data.message);
+  };
+
+  return (
+    <div>
+      <h1>Login</h1>
+      <form onSubmit={submit}>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Login</button>
+      </form>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/src/pages/recover.tsx
+++ b/src/pages/recover.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+export default function Recover() {
+  const [email, setEmail] = useState('');
+  const [token, setToken] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const requestToken = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/recover', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    });
+    const data = await res.json();
+    setMessage(data.message + (data.token ? ` Token: ${data.token}` : ''));
+  };
+
+  const resetPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/recover', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, password })
+    });
+    const data = await res.json();
+    setMessage(data.message);
+  };
+
+  return (
+    <div>
+      <h1>Recover Password</h1>
+      <form onSubmit={requestToken}>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <button type="submit">Send Token</button>
+      </form>
+      <form onSubmit={resetPassword}>
+        <input value={token} onChange={e => setToken(e.target.value)} placeholder="Token" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="New Password" />
+        <button type="submit">Reset Password</button>
+      </form>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export default function Signup() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    setMessage(res.ok ? 'Account created' : data.message);
+  };
+
+  return (
+    <div>
+      <h1>Signup</h1>
+      <form onSubmit={submit}>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Signup</button>
+      </form>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js TypeScript app with auth routes for signup, login, logout, and password recovery
- add Prisma schema and helpers for PostgreSQL
- include simple React pages for authentication flows

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1d9f1d4833397c760675d4bf1b4