### PR TITLE
Add roles and event management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,4 +16,42 @@ model User {
   resetToken    String?  @unique
   resetTokenExp DateTime?
   createdAt     DateTime @default(now())
+  role          Role     @default(CLIENT)
+  events        Event[]  @relation("EventManagerEvents")
+  ticketTypes   TicketType[] @relation("TicketTypeCreator")
+}
+
+enum Role {
+  ADMIN
+  EVENT_MANAGER
+  EVENT_RRPP
+  CLIENT
+}
+
+model Event {
+  id        Int    @id @default(autoincrement())
+  name      String
+  manager   User   @relation("EventManagerEvents", fields: [managerId], references: [id])
+  managerId Int
+  tickets   EventTicket[]
+}
+
+model TicketType {
+  id        Int    @id @default(autoincrement())
+  name      String
+  price     Float
+  creator   User   @relation("TicketTypeCreator", fields: [creatorId], references: [id])
+  creatorId Int
+  events    EventTicket[]
+}
+
+model EventTicket {
+  id           Int        @id @default(autoincrement())
+  event        Event      @relation(fields: [eventId], references: [id])
+  eventId      Int
+  ticketType   TicketType @relation(fields: [ticketTypeId], references: [id])
+  ticketTypeId Int
+  quantity     Int
+  saleStart    DateTime
+  saleEnd      DateTime
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,10 @@
+import { NextApiRequest } from 'next';
+import { prisma } from './prisma';
+
+export async function getSessionUser(req: NextApiRequest) {
+  const session = req.cookies?.session;
+  if (!session) return null;
+  const id = parseInt(session, 10);
+  if (isNaN(id)) return null;
+  return prisma.user.findUnique({ where: { id } });
+}

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -15,5 +15,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!isValid) return res.status(401).json({ message: 'Invalid credentials' });
 
   res.setHeader('Set-Cookie', `session=${user.id}; HttpOnly; Path=/; Max-Age=3600`);
-  return res.status(200).json({ id: user.id, email: user.email });
+  return res.status(200).json({ id: user.id, email: user.email, role: user.role });
 }

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+import { getSessionUser } from '../../lib/session';
+import { Role } from '@prisma/client';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const user = await getSessionUser(req);
+  if (!user || (user.role !== Role.EVENT_MANAGER && user.role !== Role.ADMIN)) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  const { name, tickets } = req.body;
+  if (!name || !Array.isArray(tickets)) {
+    return res.status(400).json({ message: 'Invalid payload' });
+  }
+
+  for (const t of tickets) {
+    if (
+      typeof t.ticketTypeId !== 'number' ||
+      typeof t.quantity !== 'number' ||
+      !t.saleStart ||
+      !t.saleEnd
+    ) {
+      return res.status(400).json({ message: 'Invalid ticket specification' });
+    }
+  }
+
+  const event = await prisma.event.create({
+    data: {
+      name,
+      managerId: user.id,
+      tickets: {
+        create: tickets.map((t: any) => ({
+          ticketTypeId: t.ticketTypeId,
+          quantity: t.quantity,
+          saleStart: new Date(t.saleStart),
+          saleEnd: new Date(t.saleEnd)
+        }))
+      }
+    },
+    include: { tickets: true }
+  });
+
+  return res.status(201).json(event);
+}

--- a/src/pages/api/ticket-types.ts
+++ b/src/pages/api/ticket-types.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+import { getSessionUser } from '../../lib/session';
+import { Role } from '@prisma/client';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const user = await getSessionUser(req);
+  if (!user || (user.role !== Role.EVENT_MANAGER && user.role !== Role.ADMIN)) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  const { name, price } = req.body;
+  if (!name || typeof price !== 'number') {
+    return res.status(400).json({ message: 'Name and price required' });
+  }
+
+  const ticketType = await prisma.ticketType.create({
+    data: { name, price, creatorId: user.id }
+  });
+
+  return res.status(201).json(ticketType);
+}

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 export default function Signup() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [role, setRole] = useState('CLIENT');
   const [message, setMessage] = useState('');
 
   const submit = async (e: React.FormEvent) => {
@@ -10,7 +11,7 @@ export default function Signup() {
     const res = await fetch('/api/auth/signup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password })
+      body: JSON.stringify({ email, password, role })
     });
     const data = await res.json();
     setMessage(res.ok ? 'Account created' : data.message);
@@ -22,6 +23,12 @@ export default function Signup() {
       <form onSubmit={submit}>
         <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
         <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <select value={role} onChange={e => setRole(e.target.value)}>
+          <option value="CLIENT">Client</option>
+          <option value="EVENT_MANAGER">Event Manager</option>
+          <option value="EVENT_RRPP">Event RRPP</option>
+          <option value="ADMIN">Admin</option>
+        </select>
         <button type="submit">Signup</button>
       </form>
       <p>{message}</p>


### PR DESCRIPTION
## Summary
- add Role enum plus Event and TicketType models to Prisma schema
- allow users to pick a role during signup
- add APIs for event managers to create ticket types and events

## Testing
- `npx prisma generate`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c37aa29c8333afa9b959bb9caf79