### PR TITLE
feat: enhance home page with navigation and dark mode

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,16 +1,40 @@
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 export default function Home() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
   return (
-    <div>
-      <h1>Bienvenido</h1>
-      <nav>
-        <ul>
+    <>
+      <nav className="navbar">
+        <div className="logo">EntraDa</div>
+        <ul className="nav-links">
           <li><Link href="/login">Login</Link></li>
           <li><Link href="/signup">Signup</Link></li>
-          <li><Link href="/recover">Recover Password</Link></li>
+          <li><Link href="/recover">Recover</Link></li>
         </ul>
+        <button className="dark-toggle" onClick={() => setDarkMode(!darkMode)}>
+          {darkMode ? 'Light' : 'Dark'}
+        </button>
       </nav>
-    </div>
+
+      <header className="hero">
+        <h1>Bienvenido a EntraDa</h1>
+        <p>Soluciones innovadoras de autenticación y gestión de usuarios.</p>
+      </header>
+
+      <section className="info">
+        <h2>Sobre la empresa</h2>
+        <p>
+          EntraDa es una empresa dedicada a proporcionar plataformas seguras y eficientes
+          para el manejo de accesos digitales. Nuestro objetivo es ayudarte a proteger la
+          información de tu organización con tecnologías modernas y fáciles de usar.
+        </p>
+      </section>
+    </>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,76 @@
+:root {
+  --bg-color: #f9fafb;
+  --text-color: #1f2937;
+  --primary-color: #2563eb;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.dark {
+  --bg-color: #1f2937;
+  --text-color: #f9fafb;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.dark .navbar {
+  background: #111827;
+}
+
+.dark-toggle {
+  background: transparent;
+  border: 2px solid #fff;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 2rem;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.info {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Summary
- add global styles and layout for a professional landing page
- implement navbar links and dark mode toggle
- include company information on home screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c40c525c833385461050193ea816