### PR TITLE
Add tests for user signup and login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .next
 .env
+build
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "echo \"No tests\" && exit 0"
+    "test": "tsc -p tsconfig.test.json && node --test build/tests/auth.test.js"
   },
   "dependencies": {
     "next": "latest",

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import signupHandler from '../src/pages/api/auth/signup';
+import loginHandler from '../src/pages/api/auth/login';
+import { prisma } from '../src/lib/prisma';
+
+function createMockReqRes({ method = 'GET', body = {} } = {}) {
+  const req = { method, body } as any;
+  let statusCode = 200;
+  let jsonData: any;
+  const headers: Record<string, string[]> = {};
+  const res: any = {
+    status(code: number) {
+      statusCode = code;
+      return this;
+    },
+    json(data: any) {
+      jsonData = data;
+      return this;
+    },
+    setHeader(name: string, value: any) {
+      headers[name.toLowerCase()] = Array.isArray(value) ? value : [value];
+    },
+    end() {
+      return this;
+    },
+    getStatus() {
+      return statusCode;
+    },
+    getJSON() {
+      return jsonData;
+    },
+    getHeaders() {
+      return headers;
+    },
+  };
+  return { req, res };
+}
+
+const users: any[] = [];
+(prisma as any).user = {
+  findUnique: async ({ where: { email } }: any) =>
+    users.find((u) => u.email === email) || null,
+  create: async ({ data }: any) => {
+    const user = { id: users.length + 1, ...data };
+    users.push(user);
+    return { id: user.id, email: user.email, passwordHash: user.passwordHash };
+  },
+};
+
+test('signup creates new user', async () => {
+  users.length = 0;
+  const { req, res } = createMockReqRes({
+    method: 'POST',
+    body: { email: 'a@a.com', password: 'pass' },
+  });
+  await signupHandler(req, res);
+  assert.equal(res.getStatus(), 201);
+  assert.deepEqual(res.getJSON(), { id: 1, email: 'a@a.com' });
+});
+
+test('signup fails if user exists', async () => {
+  users.length = 0;
+  users.push({ id: 1, email: 'a@a.com', passwordHash: 'hash' });
+  const { req, res } = createMockReqRes({
+    method: 'POST',
+    body: { email: 'a@a.com', password: 'pass' },
+  });
+  await signupHandler(req, res);
+  assert.equal(res.getStatus(), 409);
+});
+
+test('login succeeds and sets cookie', async () => {
+  users.length = 0;
+  const { req: sReq, res: sRes } = createMockReqRes({
+    method: 'POST',
+    body: { email: 'b@b.com', password: 'secret' },
+  });
+  await signupHandler(sReq, sRes);
+
+  const { req, res } = createMockReqRes({
+    method: 'POST',
+    body: { email: 'b@b.com', password: 'secret' },
+  });
+  await loginHandler(req, res);
+  assert.equal(res.getStatus(), 200);
+  const cookies = res.getHeaders()['set-cookie'];
+  assert.ok(cookies && /session=/.test(cookies[0]));
+});
+
+test('login fails with wrong password', async () => {
+  users.length = 0;
+  const { req: sReq, res: sRes } = createMockReqRes({
+    method: 'POST',
+    body: { email: 'c@c.com', password: 'correct' },
+  });
+  await signupHandler(sReq, sRes);
+
+  const { req, res } = createMockReqRes({
+    method: 'POST',
+    body: { email: 'c@c.com', password: 'wrong' },
+  });
+  await loginHandler(req, res);
+  assert.equal(res.getStatus(), 401);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./build",
+    "module": "commonjs"
+  },
+  "include": ["tests/**/*.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add comprehensive tests for user signup and login flows
- configure TypeScript test build and ignore build artifacts
- update test script to compile and run new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c65614fc8333a79ec0ce2a8edbd5