### PR TITLE
docs: add neon connection example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://neondb_owner:npg_uyIHSB8OYlC5@ep-still-glade-acdx8v5z-pooler.sa-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@ Simple Next.js app with authentication (signup, login, logout, password recovery
 - `npm start` – start production server
 
 Set a `DATABASE_URL` environment variable pointing to your PostgreSQL instance before running Prisma commands.
+
+## Vercel + Neon setup
+
+To deploy on Vercel with a Neon PostgreSQL database, set the `DATABASE_URL` environment variable in your Vercel project to the following connection string:
+
+```
+postgresql://neondb_owner:npg_uyIHSB8OYlC5@ep-still-glade-acdx8v5z-pooler.sa-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require
+```
+
+For local development, copy `.env.example` to `.env`:
+
+```
+cp .env.example .env
+```
+
+This ensures Prisma connects to the Neon instance both locally and in production.


### PR DESCRIPTION
## Summary
- document how to connect the app to a Neon PostgreSQL database on Vercel
- provide `.env.example` with the Neon connection string

## Testing
- `npm test` *(fails: signup creates new user)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c9fac0f883339362ff1879944951