### PR TITLE
Add global floating gradient navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
+
+export default function Navbar() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  return (
+    <nav className="bg-primary-gradient fixed top-4 left-1/2 transform -translate-x-1/2 w-11/12 max-w-4xl mx-auto rounded-full shadow-lg backdrop-blur-md flex items-center justify-between px-6 py-3 text-white z-50">
+      <div className="font-bold">EntraDa</div>
+      <ul className="flex space-x-4">
+        <li><Link href="/">Inicio</Link></li>
+        <li><Link href="/login">Login</Link></li>
+        <li><Link href="/signup">Signup</Link></li>
+        <li><Link href="/recover">Recover</Link></li>
+      </ul>
+      <button
+        onClick={() => setDarkMode(!darkMode)}
+        className="border-2 border-white rounded-full px-3 py-1"
+      >
+        {darkMode ? 'Light' : 'Dark'}
+      </button>
+    </nav>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,14 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
+import Navbar from '../components/Navbar';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Navbar />
+      <div className="pt-20">
+        <Component {...pageProps} />
+      </div>
+    </>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,27 +1,6 @@
-import Link from 'next/link';
-import { useEffect, useState } from 'react';
-
 export default function Home() {
-  const [darkMode, setDarkMode] = useState(false);
-
-  useEffect(() => {
-    document.body.classList.toggle('dark', darkMode);
-  }, [darkMode]);
-
   return (
     <>
-      <nav className="navbar">
-        <div className="logo">EntraDa</div>
-        <ul className="nav-links">
-          <li><Link href="/login">Login</Link></li>
-          <li><Link href="/signup">Signup</Link></li>
-          <li><Link href="/recover">Recover</Link></li>
-        </ul>
-        <button className="dark-toggle" onClick={() => setDarkMode(!darkMode)}>
-          {darkMode ? 'Light' : 'Dark'}
-        </button>
-      </nav>
-
       <header className="hero">
         <h1>Bienvenido a EntraDa</h1>
         <p>Soluciones innovadoras de autenticación y gestión de usuarios.</p>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,6 +6,7 @@
   --bg-color: #f9fafb;
   --text-color: #1f2937;
   --primary-color: #2563eb;
+  --primary-gradient: linear-gradient(to right, rgba(34,197,94,0.8), rgba(59,130,246,0.8));
 }
 
 body {
@@ -21,46 +22,6 @@ body {
   --text-color: #f9fafb;
 }
 
-.navbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  background: var(--primary-color);
-  color: #fff;
-}
-
-.logo {
-  font-size: 1.5rem;
-  font-weight: bold;
-}
-
-.nav-links {
-  list-style: none;
-  display: flex;
-  gap: 1rem;
-  margin: 0;
-  padding: 0;
-}
-
-.nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: bold;
-}
-
-.dark .navbar {
-  background: #111827;
-}
-
-.dark-toggle {
-  background: transparent;
-  border: 2px solid #fff;
-  color: #fff;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-}
 
 .hero {
   text-align: center;
@@ -77,4 +38,10 @@ body {
   margin: 0 auto;
   padding: 2rem;
   line-height: 1.6;
+}
+
+@layer utilities {
+  .bg-primary-gradient {
+    background: var(--primary-gradient);
+  }
 }


### PR DESCRIPTION
## Summary
- add floating rounded navbar with green-to-blue translucent gradient and dark-mode toggle
- expose gradient as reusable utility for future styling
- render navbar globally across pages and clean up homepage navigation

## Testing
- `npm test` *(fails: signup creates new user)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d00dd3048333b42c727421cf1a32