### PR TITLE
Add dashboard with event creation and admin user listing

### DIFF
--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -1,13 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '../../lib/prisma';
 import { getSessionUser } from '../../lib/session';
+import { Role } from '@prisma/client';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
 
   const user = await getSessionUser(req);
-  if (!user) {
-    return res.status(401).json({ message: 'Unauthorized' });
+  if (!user || (user.role !== Role.EVENT_MANAGER && user.role !== Role.ADMIN)) {
+    return res.status(403).json({ message: 'Forbidden' });
   }
 
   const { name, tickets, mercadoPagoAccount } = req.body;

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+import { getSessionUser } from '../../lib/session';
+import { Role } from '@prisma/client';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+
+  const user = await getSessionUser(req);
+  if (!user || user.role !== Role.ADMIN) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  const users = await prisma.user.findMany({
+    select: { id: true, email: true, role: true }
+  });
+
+  return res.status(200).json(users);
+}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,0 +1,85 @@
+import { GetServerSideProps } from 'next';
+import { getSessionUser } from '../lib/session';
+import { useEffect, useState } from 'react';
+import Input from '../components/Input';
+import Button from '../components/Button';
+
+interface DashboardProps {
+  user: { id: number; email: string; role: string };
+}
+
+export default function Dashboard({ user }: DashboardProps) {
+  const [name, setName] = useState('');
+  const [mpAccount, setMpAccount] = useState('');
+  const [message, setMessage] = useState('');
+  const [users, setUsers] = useState<any[]>([]);
+
+  const createEvent = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, mercadoPagoAccount: mpAccount, tickets: [] })
+    });
+    const data = await res.json();
+    setMessage(res.ok ? 'Event created' : data.message);
+  };
+
+  useEffect(() => {
+    if (user.role === 'ADMIN') {
+      fetch('/api/users')
+        .then(res => res.json())
+        .then(setUsers)
+        .catch(() => setUsers([]));
+    }
+  }, [user.role]);
+
+  return (
+    <div className="max-w-xl mx-auto mt-10 p-6 bg-white rounded shadow">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <p className="mb-4">Logged in as {user.email}</p>
+
+      {(user.role === 'EVENT_MANAGER' || user.role === 'ADMIN') && (
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Create Event</h2>
+          <form onSubmit={createEvent}>
+            <Input value={name} onChange={e => setName(e.target.value)} placeholder="Event name" />
+            <Input value={mpAccount} onChange={e => setMpAccount(e.target.value)} placeholder="MercadoPago account" />
+            <Button type="submit">Create</Button>
+          </form>
+          {message && <p className="mt-2 text-sm text-gray-600">{message}</p>}
+        </div>
+      )}
+
+      {user.role === 'ADMIN' && (
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Users</h2>
+          <ul>
+            {users.map(u => (
+              <li key={u.id} className="border-b py-1">
+                {u.email} - {u.role}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const user = await getSessionUser(ctx.req as any);
+  if (!user) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false,
+      },
+    };
+  }
+  return {
+    props: {
+      user: { id: user.id, email: user.email, role: user.role }
+    },
+  };
+};

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -15,7 +15,11 @@ export default function Login() {
       body: JSON.stringify({ email, password })
     });
     const data = await res.json();
-    setMessage(res.ok ? 'Logged in' : data.message);
+    if (res.ok) {
+      window.location.href = '/dashboard';
+    } else {
+      setMessage(data.message);
+    }
   };
 
   return (

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -44,7 +44,7 @@ const users: any[] = [];
   create: async ({ data }: any) => {
     const user = { id: users.length + 1, ...data };
     users.push(user);
-    return { id: user.id, email: user.email, passwordHash: user.passwordHash };
+    return { id: user.id, email: user.email, passwordHash: user.passwordHash, role: user.role };
   },
 };
 
@@ -56,7 +56,7 @@ test('signup creates new user', async () => {
   });
   await signupHandler(req, res);
   assert.equal(res.getStatus(), 201);
-  assert.deepEqual(res.getJSON(), { id: 1, email: 'a@a.com' });
+  assert.deepEqual(res.getJSON(), { id: 1, email: 'a@a.com', role: 'CLIENT' });
 });
 
 test('signup fails if user exists', async () => {


### PR DESCRIPTION
## Summary
- restrict event creation API to authorized roles
- expose admin-only user list API
- add dashboard after login with event creation form and admin user management
- redirect login to dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d17c9bc08333b1bde7da985ea52b