### PR TITLE
feat: add responsive navbar with auth states

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,28 +1,116 @@
 import Link from 'next/link';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
-export default function Navbar() {
-  const [darkMode, setDarkMode] = useState(false);
+interface NavbarProps {
+  isAuthenticated?: boolean;
+  isAdmin?: boolean;
+  onLogout?: () => void;
+}
 
-  useEffect(() => {
-    document.body.classList.toggle('dark', darkMode);
-  }, [darkMode]);
+export default function Navbar({
+  isAuthenticated = false,
+  isAdmin = false,
+  onLogout,
+}: NavbarProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  type NavItem = {
+    label: string;
+    href?: string;
+    type?: 'link' | 'button';
+    onClick?: () => void;
+  };
+
+  const guestItems: NavItem[] = [
+    { href: '/login', label: 'Login' },
+    { href: '/register', label: 'Register' },
+  ];
+
+  const authenticatedItems: NavItem[] = [
+    { href: '/dashboard', label: 'Dashboard' },
+    { href: '/events', label: 'Eventos' },
+    { href: '/ticket-types', label: 'Tipos de Entradas' },
+  ];
+
+  if (isAdmin) {
+    authenticatedItems.push({ href: '/users', label: 'Usuarios' });
+  }
+
+  authenticatedItems.push({ label: 'Logout', type: 'button', onClick: onLogout });
+
+  const navItems = isAuthenticated ? authenticatedItems : guestItems;
+
+  const renderItems = (itemClass: string) =>
+    navItems.map((item) =>
+      item.type === 'button' ? (
+        <button
+          key={item.label}
+          onClick={item.onClick}
+          className={`bg-red-500 text-white ${itemClass} hover:bg-red-600`}
+        >
+          {item.label}
+        </button>
+      ) : (
+        <Link
+          key={item.label}
+          href={item.href!}
+          className={`hover:bg-gray-200 ${itemClass}`}
+        >
+          {item.label}
+        </Link>
+      )
+    );
 
   return (
-    <nav className="bg-primary-gradient fixed top-4 left-1/2 transform -translate-x-1/2 w-11/12 max-w-4xl mx-auto rounded-full shadow-lg backdrop-blur-md flex items-center justify-between px-6 py-3 text-white z-50">
-      <div className="font-bold">EntraDa</div>
-      <ul className="flex space-x-4">
-        <li><Link href="/">Inicio</Link></li>
-        <li><Link href="/login">Login</Link></li>
-        <li><Link href="/signup">Signup</Link></li>
-        <li><Link href="/recover">Recover</Link></li>
-      </ul>
-      <button
-        onClick={() => setDarkMode(!darkMode)}
-        className="border-2 border-white rounded-full px-3 py-1"
-      >
-        {darkMode ? 'Light' : 'Dark'}
-      </button>
+    <nav className="fixed top-0 left-0 w-full bg-white shadow z-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between h-16">
+          <div className="flex-shrink-0 flex items-center">
+            <Link href="/" className="text-xl font-bold">
+              EntraDa
+            </Link>
+          </div>
+          <div className="flex items-center">
+            <div className="hidden md:flex md:space-x-4">
+              {renderItems('px-3 py-2 rounded block')}
+            </div>
+            <button
+              className="md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-800 hover:bg-gray-200"
+              onClick={() => setMenuOpen(!menuOpen)}
+            >
+              <svg
+                className="h-6 w-6"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                {menuOpen ? (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                ) : (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                )}
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      {menuOpen && (
+        <div className="md:hidden px-2 pt-2 pb-3 space-y-1">
+          {renderItems('block px-3 py-2 rounded')}
+        </div>
+      )}
     </nav>
   );
 }
+


### PR DESCRIPTION
## Summary
- create responsive TailwindCSS navbar
- add conditional links for auth and admin states
- include logout button styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3d4e60c88833395c9ca26d52dc5ae