### PR TITLE
Add editable events and users listings

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,14 +29,10 @@ export default function Navbar({
   const authenticatedItems: NavItem[] = [
     { href: '/dashboard', label: 'Dashboard' },
     { href: '/events', label: 'Eventos' },
+    ...(isAdmin ? [{ href: '/users', label: 'Usuarios' }] : []),
     { href: '/ticket-types', label: 'Tipos de Entradas' },
+    { label: 'Logout', type: 'button', onClick: onLogout },
   ];
-
-  if (isAdmin) {
-    authenticatedItems.push({ href: '/users', label: 'Usuarios' });
-  }
-
-  authenticatedItems.push({ label: 'Logout', type: 'button', onClick: onLogout });
 
   const navItems = isAuthenticated ? authenticatedItems : guestItems;
 

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -4,45 +4,91 @@ import { getSessionUser } from '../../lib/session';
 import { Role } from '@prisma/client';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') return res.status(405).end();
-
   const user = await getSessionUser(req);
-  if (!user || (user.role !== Role.EVENT_MANAGER && user.role !== Role.ADMIN)) {
-    return res.status(403).json({ message: 'Forbidden' });
-  }
+  if (!user) return res.status(401).json({ message: 'Unauthorized' });
 
-  const { name, tickets, mercadoPagoAccount } = req.body;
-  if (!name || !mercadoPagoAccount || !Array.isArray(tickets)) {
-    return res.status(400).json({ message: 'Invalid payload' });
-  }
-
-  for (const t of tickets) {
-    if (
-      typeof t.ticketTypeId !== 'number' ||
-      typeof t.quantity !== 'number' ||
-      !t.saleStart ||
-      !t.saleEnd
-    ) {
-      return res.status(400).json({ message: 'Invalid ticket specification' });
+  if (req.method === 'GET') {
+    if (user.role !== Role.ADMIN && user.role !== Role.EVENT_MANAGER) {
+      return res.status(403).json({ message: 'Forbidden' });
     }
+
+    const where =
+      user.role === Role.EVENT_MANAGER ? { managerId: user.id } : {};
+
+    const events = await prisma.event.findMany({
+      where,
+      select: { id: true, name: true, mercadoPagoAccount: true }
+    });
+
+    return res.status(200).json(events);
   }
 
-  const event = await prisma.event.create({
-    data: {
-      name,
-      managerId: user.id,
-      mercadoPagoAccount,
-      tickets: {
-        create: tickets.map((t: any) => ({
-          ticketTypeId: t.ticketTypeId,
-          quantity: t.quantity,
-          saleStart: new Date(t.saleStart),
-          saleEnd: new Date(t.saleEnd)
-        }))
-      }
-    },
-    include: { tickets: true }
-  });
+  if (req.method === 'PUT') {
+    if (user.role !== Role.ADMIN && user.role !== Role.EVENT_MANAGER) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
 
-  return res.status(201).json(event);
+    const { id, name, mercadoPagoAccount } = req.body;
+    if (typeof id !== 'number') {
+      return res.status(400).json({ message: 'Invalid payload' });
+    }
+
+    const event = await prisma.event.findUnique({ where: { id } });
+    if (!event) return res.status(404).json({ message: 'Event not found' });
+
+    if (user.role !== Role.ADMIN && event.managerId !== user.id) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const updated = await prisma.event.update({
+      where: { id },
+      data: { name, mercadoPagoAccount },
+      select: { id: true, name: true, mercadoPagoAccount: true }
+    });
+
+    return res.status(200).json(updated);
+  }
+
+  if (req.method === 'POST') {
+    if (user.role !== Role.EVENT_MANAGER && user.role !== Role.ADMIN) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const { name, tickets, mercadoPagoAccount } = req.body;
+    if (!name || !mercadoPagoAccount || !Array.isArray(tickets)) {
+      return res.status(400).json({ message: 'Invalid payload' });
+    }
+
+    for (const t of tickets) {
+      if (
+        typeof t.ticketTypeId !== 'number' ||
+        typeof t.quantity !== 'number' ||
+        !t.saleStart ||
+        !t.saleEnd
+      ) {
+        return res.status(400).json({ message: 'Invalid ticket specification' });
+      }
+    }
+
+    const event = await prisma.event.create({
+      data: {
+        name,
+        managerId: user.id,
+        mercadoPagoAccount,
+        tickets: {
+          create: tickets.map((t: any) => ({
+            ticketTypeId: t.ticketTypeId,
+            quantity: t.quantity,
+            saleStart: new Date(t.saleStart),
+            saleEnd: new Date(t.saleEnd)
+          }))
+        }
+      },
+      include: { tickets: true }
+    });
+
+    return res.status(201).json(event);
+  }
+
+  return res.status(405).end();
 }

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -4,16 +4,37 @@ import { getSessionUser } from '../../lib/session';
 import { Role } from '@prisma/client';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'GET') return res.status(405).end();
-
   const user = await getSessionUser(req);
   if (!user || user.role !== Role.ADMIN) {
     return res.status(403).json({ message: 'Forbidden' });
   }
 
-  const users = await prisma.user.findMany({
-    select: { id: true, email: true, role: true }
-  });
+  if (req.method === 'GET') {
+    const users = await prisma.user.findMany({
+      select: { id: true, email: true, role: true }
+    });
 
-  return res.status(200).json(users);
+    return res.status(200).json(users);
+  }
+
+  if (req.method === 'PUT') {
+    const { id, role } = req.body;
+    if (typeof id !== 'number' || !role) {
+      return res.status(400).json({ message: 'Invalid payload' });
+    }
+
+    if (!(role in Role)) {
+      return res.status(400).json({ message: 'Invalid role' });
+    }
+
+    const updated = await prisma.user.update({
+      where: { id },
+      data: { role },
+      select: { id: true, email: true, role: true }
+    });
+
+    return res.status(200).json(updated);
+  }
+
+  return res.status(405).end();
 }

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+
+interface Event {
+  id: number;
+  name: string;
+  mercadoPagoAccount: string;
+}
+
+export default function EventsPage() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [message, setMessage] = useState('');
+
+  const fetchEvents = async () => {
+    const res = await fetch('/api/events');
+    if (res.ok) {
+      setEvents(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchEvents();
+  }, []);
+
+  const handleChange = (id: number, field: keyof Event, value: string) => {
+    setEvents(prev => prev.map(e => e.id === id ? { ...e, [field]: value } : e));
+  };
+
+  const saveEvent = async (ev: Event) => {
+    const res = await fetch('/api/events', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ev)
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setMessage('Event updated');
+      fetchEvents();
+    } else {
+      setMessage(data.message);
+    }
+  };
+
+  return (
+    <div className="pt-20 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Eventos</h1>
+      {message && <p className="mb-4 text-blue-600">{message}</p>}
+      <table className="w-full">
+        <thead>
+          <tr>
+            <th className="text-left p-2">Nombre</th>
+            <th className="text-left p-2">Cuenta MP</th>
+            <th className="p-2">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map(ev => (
+            <tr key={ev.id}>
+              <td className="p-2">
+                <input
+                  className="border p-1"
+                  value={ev.name}
+                  onChange={e => handleChange(ev.id, 'name', e.target.value)}
+                />
+              </td>
+              <td className="p-2">
+                <input
+                  className="border p-1"
+                  value={ev.mercadoPagoAccount}
+                  onChange={e => handleChange(ev.id, 'mercadoPagoAccount', e.target.value)}
+                />
+              </td>
+              <td className="p-2">
+                <button
+                  className="bg-blue-500 text-white px-2 py-1 rounded"
+                  onClick={() => saveEvent(ev)}
+                >
+                  Guardar
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/users.tsx
+++ b/src/pages/users.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+type Role = 'ADMIN' | 'EVENT_MANAGER' | 'EVENT_RRPP' | 'CLIENT';
+interface User { id: number; email: string; role: Role; }
+const roles: Role[] = ['ADMIN', 'EVENT_MANAGER', 'EVENT_RRPP', 'CLIENT'];
+
+export default function UsersPage() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [message, setMessage] = useState('');
+
+  const fetchUsers = async () => {
+    const res = await fetch('/api/users');
+    if (res.ok) {
+      setUsers(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleChange = (id: number, role: Role) => {
+    setUsers(prev => prev.map(u => u.id === id ? { ...u, role } : u));
+  };
+
+  const saveUser = async (user: User) => {
+    const res = await fetch('/api/users', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: user.id, role: user.role })
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setMessage('User updated');
+      fetchUsers();
+    } else {
+      setMessage(data.message);
+    }
+  };
+
+  return (
+    <div className="pt-20 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Usuarios</h1>
+      {message && <p className="mb-4 text-blue-600">{message}</p>}
+      <table className="w-full">
+        <thead>
+          <tr>
+            <th className="text-left p-2">Email</th>
+            <th className="text-left p-2">Rol</th>
+            <th className="p-2">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map(u => (
+            <tr key={u.id}>
+              <td className="p-2">{u.email}</td>
+              <td className="p-2">
+                <select
+                  className="border p-1"
+                  value={u.role}
+                  onChange={e => handleChange(u.id, e.target.value as Role)}
+                >
+                  {roles.map(r => (
+                    <option key={r} value={r}>{r}</option>
+                  ))}
+                </select>
+              </td>
+              <td className="p-2">
+                <button
+                  className="bg-blue-500 text-white px-2 py-1 rounded"
+                  onClick={() => saveUser(u)}
+                >
+                  Guardar
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- List and update events via new API and events page
- Allow admin to view and update users from a dedicated page
- Expose events and user management links in the navbar

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d78a7a5c8333819dbcddc6ab80d8