### PR TITLE
feat: add event images and home slider

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,9 @@ model Event {
   manager   User   @relation("EventManagerEvents", fields: [managerId], references: [id])
   managerId Int
   mercadoPagoAccount String
+  posterUrl String?
+  sliderUrl String?
+  miniUrl   String?
   tickets   EventTicket[]
   ratings   Rating[]
 }

--- a/prisma/sql/add_event_images.sql
+++ b/prisma/sql/add_event_images.sql
@@ -1,0 +1,4 @@
+-- SQL migration to add image URLs to events
+ALTER TABLE "Event" ADD COLUMN "posterUrl" TEXT;
+ALTER TABLE "Event" ADD COLUMN "sliderUrl" TEXT;
+ALTER TABLE "Event" ADD COLUMN "miniUrl" TEXT;

--- a/src/components/EventSlider.tsx
+++ b/src/components/EventSlider.tsx
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+interface EventSliderProps {
+  images: string[];
+}
+
+export default function EventSlider({ images }: EventSliderProps) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (images.length === 0) return;
+    const id = setInterval(() => {
+      setIndex((prev) => (prev + 1) % images.length);
+    }, 3000);
+    return () => clearInterval(id);
+  }, [images]);
+
+  if (images.length === 0) return null;
+
+  return (
+    <div className="relative w-full h-64 overflow-hidden mb-4">
+      {images.map((img, i) => (
+        <img
+          key={i}
+          src={img}
+          alt={`Slide ${i + 1}`}
+          className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-700 ${i === index ? 'opacity-100' : 'opacity-0'}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -11,7 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(403).json({ message: 'Forbidden' });
   }
 
-  const { name, tickets, mercadoPagoAccount } = req.body;
+  const { name, tickets, mercadoPagoAccount, posterUrl, sliderUrl, miniUrl } = req.body;
   if (!name || !mercadoPagoAccount || !Array.isArray(tickets)) {
     return res.status(400).json({ message: 'Invalid payload' });
   }
@@ -32,6 +32,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       name,
       managerId: user.id,
       mercadoPagoAccount,
+      posterUrl,
+      sliderUrl,
+      miniUrl,
       tickets: {
         create: tickets.map((t: any) => ({
           ticketTypeId: t.ticketTypeId,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,23 @@
-export default function Home() {
+import type { GetServerSideProps } from 'next';
+import EventSlider from '../components/EventSlider';
+import { prisma } from '../lib/prisma';
+
+interface HomeProps {
+  sliderImages: string[];
+}
+
+export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
+  const events = await prisma.event.findMany({
+    select: { sliderUrl: true },
+    where: { sliderUrl: { not: null } },
+  });
+  return { props: { sliderImages: events.map((e) => e.sliderUrl as string) } };
+};
+
+export default function Home({ sliderImages }: HomeProps) {
   return (
     <>
+      <EventSlider images={sliderImages} />
       <header className="hero">
         <h1>Bienvenido a EntraDa</h1>
         <p>Soluciones innovadoras de autenticación y gestión de usuarios.</p>


### PR DESCRIPTION
## Summary
- add poster, slider, and mini image fields to events
- expose image URLs in event creation API
- show event slider on the home page
- provide SQL migration for new image columns

## Testing
- `npx prisma generate`
- `npx tsc --noEmit && echo 'Type check passed'`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d8214f4c83338df2a0354b2b5587