### PR TITLE
feat: add localized email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ cp .env.example .env
 ```
 
 This ensures Prisma connects to the Neon instance both locally and in production.
+
+## Email sending
+
+Password recovery emails are sent through the [Resend](https://resend.com) API. To enable this feature set the following environment variables in Vercel or your local `.env` file:
+
+- `RESEND_API_KEY` – your Resend API key
+- `RESEND_FROM` – (optional) the email address used in the `from` field
+
+If `RESEND_API_KEY` is not provided, the application will skip sending emails.
+
+Email templates for welcome, verification, and password recovery messages are available in English and Spanish. The password recovery endpoint accepts an optional `lang` field (`en` or `es`) to select the language of the email.

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,52 @@
+import {
+  buildPasswordResetEmail,
+  buildVerificationEmail,
+  buildWelcomeEmail,
+  type Locale
+} from './emailTemplates';
+
+export async function sendEmail(to: string, subject: string, html: string) {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.warn('RESEND_API_KEY not set; email not sent');
+    return;
+  }
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      from: process.env.RESEND_FROM || 'onboarding@resend.dev',
+      to,
+      subject,
+      html
+    })
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('Failed to send email', res.status, text);
+    throw new Error('Failed to send email');
+  }
+}
+
+export async function sendWelcomeEmail(to: string, name: string, locale: Locale) {
+  const { subject, html } = buildWelcomeEmail(locale, name);
+  await sendEmail(to, subject, html);
+}
+
+export async function sendVerificationEmail(to: string, link: string, locale: Locale) {
+  const { subject, html } = buildVerificationEmail(locale, link);
+  await sendEmail(to, subject, html);
+}
+
+export async function sendPasswordResetEmail(to: string, token: string, locale: Locale) {
+  const { subject, html } = buildPasswordResetEmail(locale, token);
+  await sendEmail(to, subject, html);
+}
+
+export type { Locale } from './emailTemplates';
+

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -1,0 +1,52 @@
+export type Locale = 'en' | 'es';
+
+interface EmailContent {
+  subject: string;
+  html: string;
+}
+
+const templates = {
+  en: {
+    welcome: (name: string): EmailContent => ({
+      subject: 'Welcome to EntraDa',
+      html: `<p>Welcome, ${name}!</p>`
+    }),
+    verification: (link: string): EmailContent => ({
+      subject: 'Verify your email',
+      html: `<p>Please verify your email by clicking <a href="${link}">here</a>.</p>`
+    }),
+    reset: (token: string): EmailContent => ({
+      subject: 'Password Recovery',
+      html: `<p>Your password reset token is: <strong>${token}</strong></p>`
+    })
+  },
+  es: {
+    welcome: (name: string): EmailContent => ({
+      subject: 'Bienvenido a EntraDa',
+      html: `<p>¡Bienvenido, ${name}!</p>`
+    }),
+    verification: (link: string): EmailContent => ({
+      subject: 'Verifica tu correo',
+      html: `<p>Por favor verifica tu correo haciendo clic <a href="${link}">aquí</a>.</p>`
+    }),
+    reset: (token: string): EmailContent => ({
+      subject: 'Recuperación de contraseña',
+      html: `<p>Tu token de restablecimiento es: <strong>${token}</strong></p>`
+    })
+  }
+} as const;
+
+export function buildWelcomeEmail(locale: Locale, name: string): EmailContent {
+  const t = templates[locale] || templates.en;
+  return t.welcome(name);
+}
+
+export function buildVerificationEmail(locale: Locale, link: string): EmailContent {
+  const t = templates[locale] || templates.en;
+  return t.verification(link);
+}
+
+export function buildPasswordResetEmail(locale: Locale, token: string): EmailContent {
+  const t = templates[locale] || templates.en;
+  return t.reset(token);
+}


### PR DESCRIPTION
## Summary
- add welcome, verification and password reset templates with English and Spanish variants
- expose helpers to send localized emails through Resend
- allow password recovery API to select language via `lang` field and document templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d7c30ee08333b05da4948fcbe9b1