### PR TITLE
Add event image URLs and homepage slider

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,9 @@ model Event {
   manager   User   @relation("EventManagerEvents", fields: [managerId], references: [id])
   managerId Int
   mercadoPagoAccount String
+  posterUrl String?
+  sliderUrl String?
+  miniUrl   String?
   tickets   EventTicket[]
   ratings   Rating[]
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -11,6 +11,9 @@ interface DashboardProps {
 export default function Dashboard({ user }: DashboardProps) {
   const [name, setName] = useState('');
   const [mpAccount, setMpAccount] = useState('');
+  const [posterUrl, setPosterUrl] = useState('');
+  const [sliderUrl, setSliderUrl] = useState('');
+  const [miniUrl, setMiniUrl] = useState('');
   const [message, setMessage] = useState('');
   const [users, setUsers] = useState<any[]>([]);
 
@@ -19,7 +22,14 @@ export default function Dashboard({ user }: DashboardProps) {
     const res = await fetch('/api/events', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, mercadoPagoAccount: mpAccount, tickets: [] })
+      body: JSON.stringify({
+        name,
+        mercadoPagoAccount: mpAccount,
+        posterUrl,
+        sliderUrl,
+        miniUrl,
+        tickets: [],
+      }),
     });
     const data = await res.json();
     setMessage(res.ok ? 'Event created' : data.message);
@@ -45,6 +55,9 @@ export default function Dashboard({ user }: DashboardProps) {
           <form onSubmit={createEvent}>
             <Input value={name} onChange={e => setName(e.target.value)} placeholder="Event name" />
             <Input value={mpAccount} onChange={e => setMpAccount(e.target.value)} placeholder="MercadoPago account" />
+            <Input value={posterUrl} onChange={e => setPosterUrl(e.target.value)} placeholder="Poster URL" />
+            <Input value={sliderUrl} onChange={e => setSliderUrl(e.target.value)} placeholder="Slider URL" />
+            <Input value={miniUrl} onChange={e => setMiniUrl(e.target.value)} placeholder="Mini URL" />
             <Button type="submit">Create</Button>
           </form>
           {message && <p className="mt-2 text-sm text-gray-600">{message}</p>}

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -4,6 +4,9 @@ interface Event {
   id: number;
   name: string;
   mercadoPagoAccount: string;
+  posterUrl?: string;
+  sliderUrl?: string;
+  miniUrl?: string;
 }
 
 export default function EventsPage() {
@@ -49,6 +52,9 @@ export default function EventsPage() {
           <tr>
             <th className="text-left p-2">Nombre</th>
             <th className="text-left p-2">Cuenta MP</th>
+            <th className="text-left p-2">Poster URL</th>
+            <th className="text-left p-2">Slider URL</th>
+            <th className="text-left p-2">Mini URL</th>
             <th className="p-2">Acciones</th>
           </tr>
         </thead>
@@ -67,6 +73,27 @@ export default function EventsPage() {
                   className="border p-1"
                   value={ev.mercadoPagoAccount}
                   onChange={e => handleChange(ev.id, 'mercadoPagoAccount', e.target.value)}
+                />
+              </td>
+              <td className="p-2">
+                <input
+                  className="border p-1"
+                  value={ev.posterUrl || ''}
+                  onChange={e => handleChange(ev.id, 'posterUrl', e.target.value)}
+                />
+              </td>
+              <td className="p-2">
+                <input
+                  className="border p-1"
+                  value={ev.sliderUrl || ''}
+                  onChange={e => handleChange(ev.id, 'sliderUrl', e.target.value)}
+                />
+              </td>
+              <td className="p-2">
+                <input
+                  className="border p-1"
+                  value={ev.miniUrl || ''}
+                  onChange={e => handleChange(ev.id, 'miniUrl', e.target.value)}
                 />
               </td>
               <td className="p-2">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,55 @@
+import { useEffect, useState } from 'react';
+
+interface Event {
+  id: number;
+  name: string;
+  posterUrl?: string;
+}
+
 export default function Home() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    fetch('/api/events')
+      .then(res => res.json())
+      .then(setEvents)
+      .catch(() => setEvents([]));
+  }, []);
+
+  const next = () => setCurrent((current + 1) % events.length);
+  const prev = () => setCurrent((current - 1 + events.length) % events.length);
+
   return (
     <>
+      {events.length > 0 && (
+        <div className="relative w-full h-64 overflow-hidden mb-8">
+          {events[current].posterUrl && (
+            <img
+              src={events[current].posterUrl || ''}
+              alt={events[current].name}
+              className="w-full h-full object-cover"
+            />
+          )}
+          {events.length > 1 && (
+            <>
+              <button
+                onClick={prev}
+                className="absolute left-0 top-1/2 -translate-y-1/2 bg-white bg-opacity-50 px-2"
+              >
+                ‹
+              </button>
+              <button
+                onClick={next}
+                className="absolute right-0 top-1/2 -translate-y-1/2 bg-white bg-opacity-50 px-2"
+              >
+                ›
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
       <header className="hero">
         <h1>Bienvenido a EntraDa</h1>
         <p>Soluciones innovadoras de autenticación y gestión de usuarios.</p>


### PR DESCRIPTION
## Summary
- allow storing poster, slider and mini URLs for events
- expose image URLs via API and event management screens
- add homepage slider showcasing event posters

## Testing
- `npx prisma generate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3db6ba0e483338120c4e7a2b91bf8