### PR TITLE
feat: send password recovery emails via Resend

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ cp .env.example .env
 ```
 
 This ensures Prisma connects to the Neon instance both locally and in production.
+
+## Email sending
+
+Password recovery emails are sent through the [Resend](https://resend.com) API. To enable this feature set the following environment variables in Vercel or your local `.env` file:
+
+- `RESEND_API_KEY` – your Resend API key
+- `RESEND_FROM` – (optional) the email address used in the `from` field
+
+If `RESEND_API_KEY` is not provided, the application will skip sending emails.

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,28 @@
+export async function sendEmail(to: string, subject: string, html: string) {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.warn('RESEND_API_KEY not set; email not sent');
+    return;
+  }
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      from: process.env.RESEND_FROM || 'onboarding@resend.dev',
+      to,
+      subject,
+      html
+    })
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('Failed to send email', res.status, text);
+    throw new Error('Failed to send email');
+  }
+}
+

--- a/src/pages/api/auth/recover.ts
+++ b/src/pages/api/auth/recover.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '../../../lib/prisma';
 import { hashPassword } from '../../../lib/auth';
+import { sendEmail } from '../../../lib/email';
 import crypto from 'crypto';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -17,6 +18,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       where: { email },
       data: { resetToken: token, resetTokenExp }
     });
+
+    await sendEmail(
+      email,
+      'Password Recovery',
+      `<p>Your password reset token is: <strong>${token}</strong></p>`
+    );
 
     return res.status(200).json({ message: 'Reset token generated', token });
   } else if (req.method === 'PUT') {


### PR DESCRIPTION
## Summary
- create email helper that calls Resend API
- send password recovery tokens via email
- document email environment variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d7c30ee08333b05da4948fcbe9b1