### PR TITLE
Add ticket type CRUD interface

### DIFF
--- a/src/pages/api/ticket-types.ts
+++ b/src/pages/api/ticket-types.ts
@@ -4,21 +4,69 @@ import { getSessionUser } from '../../lib/session';
 import { Role } from '@prisma/client';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') return res.status(405).end();
-
   const user = await getSessionUser(req);
+
+  if (req.method === 'GET') {
+    if (!user || (user.role !== Role.EVENT_MANAGER && user.role !== Role.ADMIN)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const { id } = req.query;
+    const where = id && typeof id === 'string' ? { id: Number(id) } : {};
+    const ticketTypes = await prisma.ticketType.findMany({
+      where,
+      select: { id: true, name: true, price: true }
+    });
+
+    if (id) {
+      return res.status(200).json(ticketTypes[0] || null);
+    }
+
+    return res.status(200).json(ticketTypes);
+  }
+
   if (!user || (user.role !== Role.EVENT_MANAGER && user.role !== Role.ADMIN)) {
     return res.status(403).json({ message: 'Forbidden' });
   }
 
-  const { name, price } = req.body;
-  if (!name || typeof price !== 'number') {
-    return res.status(400).json({ message: 'Name and price required' });
+  if (req.method === 'POST') {
+    const { name, price } = req.body;
+    if (!name || typeof price !== 'number') {
+      return res.status(400).json({ message: 'Name and price required' });
+    }
+
+    const ticketType = await prisma.ticketType.create({
+      data: { name, price, creatorId: user.id }
+    });
+
+    return res.status(201).json(ticketType);
   }
 
-  const ticketType = await prisma.ticketType.create({
-    data: { name, price, creatorId: user.id }
-  });
+  if (req.method === 'PUT') {
+    const { id, name, price } = req.body;
+    if (typeof id !== 'number' || !name || typeof price !== 'number') {
+      return res.status(400).json({ message: 'Invalid payload' });
+    }
 
-  return res.status(201).json(ticketType);
+    const updated = await prisma.ticketType.update({
+      where: { id },
+      data: { name, price },
+      select: { id: true, name: true, price: true }
+    });
+
+    return res.status(200).json(updated);
+  }
+
+  if (req.method === 'DELETE') {
+    const { id } = req.query;
+    const ttId = Number(id);
+    if (!id || Array.isArray(id) || isNaN(ttId)) {
+      return res.status(400).json({ message: 'Invalid id' });
+    }
+
+    await prisma.ticketType.delete({ where: { id: ttId } });
+    return res.status(204).end();
+  }
+
+  return res.status(405).end();
 }

--- a/src/pages/ticket-types/[id].tsx
+++ b/src/pages/ticket-types/[id].tsx
@@ -1,0 +1,72 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+interface TicketType {
+  id: number;
+  name: string;
+  price: number;
+}
+
+export default function EditTicketType() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [ticketType, setTicketType] = useState<TicketType | null>(null);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (id) {
+      fetch(`/api/ticket-types?id=${id}`)
+        .then(res => res.json())
+        .then(setTicketType)
+        .catch(() => setTicketType(null));
+    }
+  }, [id]);
+
+  const handleChange = (field: keyof TicketType, value: string) => {
+    if (!ticketType) return;
+    setTicketType({ ...ticketType, [field]: field === 'price' ? Number(value) : value });
+  };
+
+  const saveType = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!ticketType) return;
+    const res = await fetch('/api/ticket-types', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ticketType)
+    });
+    const data = await res.json();
+    if (res.ok) {
+      router.push('/ticket-types');
+    } else {
+      setMessage(data.message);
+    }
+  };
+
+  if (!ticketType) {
+    return <div className="pt-20 max-w-xl mx-auto">Loading...</div>;
+  }
+
+  return (
+    <div className="pt-20 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Editar tipo de entrada</h1>
+      {message && <p className="mb-4 text-blue-600">{message}</p>}
+      <form onSubmit={saveType} className="space-y-2">
+        <input
+          className="border p-1 w-full"
+          value={ticketType.name}
+          onChange={e => handleChange('name', e.target.value)}
+        />
+        <input
+          className="border p-1 w-full"
+          type="number"
+          value={ticketType.price}
+          onChange={e => handleChange('price', e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1 rounded">
+          Guardar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/ticket-types/index.tsx
+++ b/src/pages/ticket-types/index.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+interface TicketType {
+  id: number;
+  name: string;
+  price: number;
+}
+
+export default function TicketTypesPage() {
+  const [ticketTypes, setTicketTypes] = useState<TicketType[]>([]);
+  const [message, setMessage] = useState('');
+  const [newName, setNewName] = useState('');
+  const [newPrice, setNewPrice] = useState('');
+  const router = useRouter();
+
+  const fetchTypes = async () => {
+    const res = await fetch('/api/ticket-types');
+    if (res.ok) {
+      setTicketTypes(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchTypes();
+  }, []);
+
+  const createType = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/ticket-types', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName, price: Number(newPrice) })
+    });
+    const data = await res.json().catch(() => null);
+    if (res.ok) {
+      setNewName('');
+      setNewPrice('');
+      fetchTypes();
+    } else if (data) {
+      setMessage(data.message);
+    }
+  };
+
+  const deleteType = async (id: number) => {
+    if (!confirm('¿Borrar tipo de entrada?')) return;
+    const res = await fetch(`/api/ticket-types?id=${id}`, { method: 'DELETE' });
+    const data = res.status === 204 ? null : await res.json();
+    if (res.ok) {
+      setMessage('Ticket type deleted');
+      fetchTypes();
+    } else if (data) {
+      setMessage(data.message);
+    }
+  };
+
+  return (
+    <div className="pt-20 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Tipos de entradas</h1>
+      {message && <p className="mb-4 text-blue-600">{message}</p>}
+      <form onSubmit={createType} className="mb-4 space-x-2">
+        <input
+          className="border p-1"
+          placeholder="Nombre"
+          value={newName}
+          onChange={e => setNewName(e.target.value)}
+        />
+        <input
+          className="border p-1"
+          placeholder="Precio"
+          type="number"
+          value={newPrice}
+          onChange={e => setNewPrice(e.target.value)}
+        />
+        <button type="submit" className="bg-green-500 text-white px-2 py-1 rounded">
+          Crear
+        </button>
+      </form>
+      <table className="w-full">
+        <thead>
+          <tr>
+            <th className="text-left p-2">Nombre</th>
+            <th className="text-left p-2">Precio</th>
+            <th className="p-2">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ticketTypes.map(tt => (
+            <tr key={tt.id}>
+              <td className="p-2">{tt.name}</td>
+              <td className="p-2">{tt.price}</td>
+              <td className="p-2 space-x-2">
+                <button
+                  className="bg-blue-500 text-white px-2 py-1 rounded"
+                  onClick={() => router.push(`/ticket-types/${tt.id}`)}
+                >
+                  Editar
+                </button>
+                <button
+                  className="bg-red-500 text-white px-2 py-1 rounded"
+                  onClick={() => deleteType(tt.id)}
+                >
+                  Borrar
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend ticket type API with GET, PUT and DELETE handlers
- add admin pages to list, create, edit and delete ticket types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4bddc01508333849b0255de107637