### PR TITLE
Support ticket details during event creation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ enum Role {
 model Event {
   id        Int    @id @default(autoincrement())
   name      String
+  date      DateTime
   manager   User   @relation("EventManagerEvents", fields: [managerId], references: [id])
   managerId Int
   mercadoPagoAccount String

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -21,12 +21,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ? {
           id: true,
           name: true,
+          date: true,
           mercadoPagoAccount: true,
           posterUrl: true,
           sliderUrl: true,
           miniUrl: true,
         }
-      : { id: true, name: true, posterUrl: true };
+      : { id: true, name: true, posterUrl: true, date: true };
 
     const events = await prisma.event.findMany({ where, select });
 
@@ -44,8 +45,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ message: 'Forbidden' });
     }
 
-    const { id, name, mercadoPagoAccount, posterUrl, sliderUrl, miniUrl } = req.body;
-    if (typeof id !== 'number') {
+    const { id, name, date, mercadoPagoAccount, posterUrl, sliderUrl, miniUrl } = req.body;
+    if (typeof id !== 'number' || !date) {
       return res.status(400).json({ message: 'Invalid payload' });
     }
 
@@ -58,10 +59,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const updated = await prisma.event.update({
       where: { id },
-      data: { name, mercadoPagoAccount, posterUrl, sliderUrl, miniUrl },
+      data: { name, date: new Date(date), mercadoPagoAccount, posterUrl, sliderUrl, miniUrl },
       select: {
         id: true,
         name: true,
+        date: true,
         mercadoPagoAccount: true,
         posterUrl: true,
         sliderUrl: true,
@@ -77,17 +79,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ message: 'Forbidden' });
     }
 
-    const { name, tickets, mercadoPagoAccount, posterUrl, sliderUrl, miniUrl } = req.body;
-    if (!name || !mercadoPagoAccount || !Array.isArray(tickets)) {
+    const { name, date, tickets, mercadoPagoAccount, posterUrl, sliderUrl, miniUrl } = req.body;
+    if (!name || !date || !mercadoPagoAccount || !Array.isArray(tickets)) {
       return res.status(400).json({ message: 'Invalid payload' });
     }
 
     for (const t of tickets) {
       if (
-        typeof t.ticketTypeId !== 'number' ||
+        !t.name ||
+        typeof t.price !== 'number' ||
         typeof t.quantity !== 'number' ||
-        !t.saleStart ||
-        !t.saleEnd
+        !t.saleStart
       ) {
         return res.status(400).json({ message: 'Invalid ticket specification' });
       }
@@ -96,6 +98,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const event = await prisma.event.create({
       data: {
         name,
+        date: new Date(date),
         managerId: user.id,
         mercadoPagoAccount,
         posterUrl,
@@ -103,10 +106,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         miniUrl,
         tickets: {
           create: tickets.map((t: any) => ({
-            ticketTypeId: t.ticketTypeId,
             quantity: t.quantity,
             saleStart: new Date(t.saleStart),
-            saleEnd: new Date(t.saleEnd),
+            saleEnd: new Date(date),
+            ticketType: {
+              create: {
+                name: t.name,
+                price: t.price,
+                creatorId: user.id,
+              },
+            },
           })),
         },
       },

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -10,10 +10,15 @@ interface DashboardProps {
 
 export default function Dashboard({ user }: DashboardProps) {
   const [name, setName] = useState('');
+  const [date, setDate] = useState('');
   const [mpAccount, setMpAccount] = useState('');
   const [posterUrl, setPosterUrl] = useState('');
   const [sliderUrl, setSliderUrl] = useState('');
   const [miniUrl, setMiniUrl] = useState('');
+  const [ticketName, setTicketName] = useState('');
+  const [ticketPrice, setTicketPrice] = useState('');
+  const [ticketQuantity, setTicketQuantity] = useState('');
+  const [ticketSaleStart, setTicketSaleStart] = useState('');
   const [message, setMessage] = useState('');
   const [users, setUsers] = useState<any[]>([]);
 
@@ -24,11 +29,19 @@ export default function Dashboard({ user }: DashboardProps) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         name,
+        date,
         mercadoPagoAccount: mpAccount,
         posterUrl,
         sliderUrl,
         miniUrl,
-        tickets: [],
+        tickets: [
+          {
+            name: ticketName,
+            price: Number(ticketPrice),
+            quantity: Number(ticketQuantity),
+            saleStart: ticketSaleStart,
+          },
+        ],
       }),
     });
     const data = await res.json();
@@ -54,10 +67,18 @@ export default function Dashboard({ user }: DashboardProps) {
           <h2 className="text-xl font-semibold mb-2">Create Event</h2>
           <form onSubmit={createEvent}>
             <Input value={name} onChange={e => setName(e.target.value)} placeholder="Event name" />
+            <Input type="date" value={date} onChange={e => setDate(e.target.value)} placeholder="Event date" />
             <Input value={mpAccount} onChange={e => setMpAccount(e.target.value)} placeholder="MercadoPago account" />
             <Input value={posterUrl} onChange={e => setPosterUrl(e.target.value)} placeholder="Poster URL" />
             <Input value={sliderUrl} onChange={e => setSliderUrl(e.target.value)} placeholder="Slider URL" />
             <Input value={miniUrl} onChange={e => setMiniUrl(e.target.value)} placeholder="Mini URL" />
+            <div className="mt-4">
+              <h3 className="font-semibold mb-2">Ticket Type</h3>
+              <Input value={ticketName} onChange={e => setTicketName(e.target.value)} placeholder="Ticket name" />
+              <Input type="number" value={ticketPrice} onChange={e => setTicketPrice(e.target.value)} placeholder="Price" />
+              <Input type="number" value={ticketQuantity} onChange={e => setTicketQuantity(e.target.value)} placeholder="Quantity" />
+              <Input type="date" value={ticketSaleStart} onChange={e => setTicketSaleStart(e.target.value)} placeholder="Sale start" />
+            </div>
             <Button type="submit">Create</Button>
           </form>
           {message && <p className="mt-2 text-sm text-gray-600">{message}</p>}

--- a/src/pages/events/[id].tsx
+++ b/src/pages/events/[id].tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 interface Event {
   id: number;
   name: string;
+  date: string;
   mercadoPagoAccount: string;
   posterUrl?: string;
   sliderUrl?: string;
@@ -59,6 +60,12 @@ export default function EditEvent() {
           className="border p-1 w-full"
           value={event.name}
           onChange={e => handleChange('name', e.target.value)}
+        />
+        <input
+          type="date"
+          className="border p-1 w-full"
+          value={event.date ? event.date.split('T')[0] : ''}
+          onChange={e => handleChange('date', e.target.value)}
         />
         <input
           className="border p-1 w-full"

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 interface Event {
   id: number;
   name: string;
+  date: string;
   mercadoPagoAccount: string;
   posterUrl?: string;
   sliderUrl?: string;
@@ -46,6 +47,7 @@ export default function EventsPage() {
         <thead>
           <tr>
             <th className="text-left p-2">Nombre</th>
+            <th className="text-left p-2">Fecha</th>
             <th className="text-left p-2">Cuenta MP</th>
             <th className="text-left p-2">Poster</th>
             <th className="text-left p-2">Slider</th>
@@ -57,6 +59,7 @@ export default function EventsPage() {
           {events.map(ev => (
             <tr key={ev.id}>
               <td className="p-2">{ev.name}</td>
+              <td className="p-2">{new Date(ev.date).toLocaleDateString()}</td>
               <td className="p-2">{ev.mercadoPagoAccount}</td>
               <td className="p-2">
                 {ev.posterUrl && (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ interface Event {
   id: number;
   name: string;
   posterUrl?: string;
+  date?: string;
 }
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- Add `date` to Event schema
- Create ticket types with quantity, price and sale start when creating events
- Capture event date and ticket information in dashboard form

## Testing
- `npx prisma generate`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c1e8ae788333a95d0915253d4371