### PR TITLE
Add event slider on home page

### DIFF
--- a/src/components/EventSlider.tsx
+++ b/src/components/EventSlider.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+export interface Event {
+  id: number;
+  name: string;
+  posterUrl?: string;
+  sliderUrl?: string;
+}
+
+export default function EventSlider({ events }: { events: Event[] }) {
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    if (events.length > 1) {
+      const id = setInterval(() => {
+        setCurrent(c => (c + 1) % events.length);
+      }, 3000);
+      return () => clearInterval(id);
+    }
+  }, [events.length]);
+
+  const next = () => setCurrent(c => (c + 1) % events.length);
+  const prev = () => setCurrent(c => (c - 1 + events.length) % events.length);
+
+  if (events.length === 0) return null;
+
+  return (
+    <div className="relative w-full h-64 overflow-hidden mb-8">
+      {events.map((ev, idx) => (
+        ev.sliderUrl || ev.posterUrl ? (
+          <img
+            key={ev.id}
+            src={ev.sliderUrl || ev.posterUrl || ''}
+            alt={ev.name}
+            className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-1000 ${
+              idx === current ? 'opacity-100' : 'opacity-0'
+            }`}
+          />
+        ) : null
+      ))}
+      {events.length > 1 && (
+        <>
+          <button
+            onClick={prev}
+            className="absolute left-0 top-1/2 -translate-y-1/2 bg-white bg-opacity-50 px-2"
+          >
+            ‹
+          </button>
+          <button
+            onClick={next}
+            className="absolute right-0 top-1/2 -translate-y-1/2 bg-white bg-opacity-50 px-2"
+          >
+            ›
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,16 +1,8 @@
 import { useEffect, useState } from 'react';
-
-interface Event {
-  id: number;
-  name: string;
-  posterUrl?: string;
-  date?: string;
-  sliderUrl?: string;
-}
+import EventSlider, { Event } from '../components/EventSlider';
 
 export default function Home() {
   const [events, setEvents] = useState<Event[]>([]);
-  const [current, setCurrent] = useState(0);
 
   useEffect(() => {
     fetch('/api/events')
@@ -19,52 +11,9 @@ export default function Home() {
       .catch(() => setEvents([]));
   }, []);
 
-  useEffect(() => {
-    if (events.length > 1) {
-      const id = setInterval(() => {
-        setCurrent(c => (c + 1) % events.length);
-      }, 3000);
-      return () => clearInterval(id);
-    }
-  }, [events.length]);
-
-  const next = () => setCurrent((current + 1) % events.length);
-  const prev = () => setCurrent((current - 1 + events.length) % events.length);
-
   return (
     <>
-      {events.length > 0 && (
-        <div className="relative w-full h-64 overflow-hidden mb-8">
-          {events.map((ev, idx) => (
-            ev.sliderUrl || ev.posterUrl ? (
-              <img
-                key={ev.id}
-                src={ev.sliderUrl || ev.posterUrl || ''}
-                alt={ev.name}
-                className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-1000 ${
-                  idx === current ? 'opacity-100' : 'opacity-0'
-                }`}
-              />
-            ) : null
-          ))}
-          {events.length > 1 && (
-            <>
-              <button
-                onClick={prev}
-                className="absolute left-0 top-1/2 -translate-y-1/2 bg-white bg-opacity-50 px-2"
-              >
-                ‹
-              </button>
-              <button
-                onClick={next}
-                className="absolute right-0 top-1/2 -translate-y-1/2 bg-white bg-opacity-50 px-2"
-              >
-                ›
-              </button>
-            </>
-          )}
-        </div>
-      )}
+      <EventSlider events={events} />
 
       <header className="hero">
         <h1>Bienvenido a EntraDa</h1>


### PR DESCRIPTION
## Summary
- create reusable `EventSlider` component cycling through event posters every 3 seconds
- use `EventSlider` on the home page after loading events from the API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4efd6d98483339ad57888551be5f7