### PR TITLE
feat: add reusable date picker component

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Input from './Input';
+
+// Reusable date picker based on the generic Input component
+// Allows consistent styling for all date inputs in the app
+
+type DatePickerProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'>;
+
+export default function DatePicker(props: DatePickerProps) {
+  return <Input type="date" {...props} />;
+}
+

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -3,6 +3,7 @@ import { getSessionUser } from '../lib/session';
 import { useEffect, useState } from 'react';
 import Input from '../components/Input';
 import Button from '../components/Button';
+import DatePicker from '../components/DatePicker';
 
 interface DashboardProps {
   user: { id: number; email: string; role: string };
@@ -65,7 +66,7 @@ export default function Dashboard({ user }: DashboardProps) {
           <h2 className="text-xl font-semibold mb-2">Create Event</h2>
           <form onSubmit={createEvent}>
             <Input value={name} onChange={e => setName(e.target.value)} placeholder="Event name" />
-            <Input type="date" value={date} onChange={e => setDate(e.target.value)} placeholder="Event date" />
+            <DatePicker value={date} onChange={e => setDate(e.target.value)} placeholder="Event date" />
             <Input value={mpAccount} onChange={e => setMpAccount(e.target.value)} placeholder="MercadoPago account" />
             <Input value={posterUrl} onChange={e => setPosterUrl(e.target.value)} placeholder="Poster URL" />
             <Input value={sliderUrl} onChange={e => setSliderUrl(e.target.value)} placeholder="Slider URL" />
@@ -102,8 +103,7 @@ export default function Dashboard({ user }: DashboardProps) {
                   }}
                   placeholder="Quantity"
                 />
-                <Input
-                  type="date"
+                <DatePicker
                   value={ticket.saleStart}
                   onChange={e => {
                     const updated = [...tickets];

--- a/src/pages/events/[id].tsx
+++ b/src/pages/events/[id].tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import DatePicker from '../../components/DatePicker';
 
 interface Event {
   id: number;
@@ -61,9 +62,7 @@ export default function EditEvent() {
           value={event.name}
           onChange={e => handleChange('name', e.target.value)}
         />
-        <input
-          type="date"
-          className="border p-1 w-full"
+        <DatePicker
           value={event.date ? event.date.split('T')[0] : ''}
           onChange={e => handleChange('date', e.target.value)}
         />


### PR DESCRIPTION
## Summary
- add DatePicker component wrapping Input for consistent date fields
- use DatePicker in event creation and editing forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f3d01efc8333b10a98a83910d7fd