### PR TITLE
Allow editing event ticket types

### DIFF
--- a/src/pages/events/[id].tsx
+++ b/src/pages/events/[id].tsx
@@ -11,18 +11,38 @@ interface Event {
   miniUrl?: string;
 }
 
+type TicketInput = { name: string; price: string; quantity: string; saleStart: string };
+
 export default function EditEvent() {
   const router = useRouter();
   const { id } = router.query;
   const [event, setEvent] = useState<Event | null>(null);
+  const [tickets, setTickets] = useState<TicketInput[]>([
+    { name: '', price: '', quantity: '', saleStart: '' },
+  ]);
   const [message, setMessage] = useState('');
 
   useEffect(() => {
     if (id) {
       fetch(`/api/events?id=${id}`)
         .then(res => res.json())
-        .then(setEvent)
-        .catch(() => setEvent(null));
+        .then(data => {
+          setEvent(data);
+          if (data.ticketTypes && data.ticketTypes.length > 0) {
+            setTickets(
+              data.ticketTypes.map((t: any) => ({
+                name: t.name,
+                price: String(t.price),
+                quantity: String(t.quantity),
+                saleStart: t.saleStart ? t.saleStart.split('T')[0] : '',
+              }))
+            );
+          }
+        })
+        .catch(() => {
+          setEvent(null);
+          setTickets([{ name: '', price: '', quantity: '', saleStart: '' }]);
+        });
     }
   }, [id]);
 
@@ -37,7 +57,15 @@ export default function EditEvent() {
     const res = await fetch('/api/events', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(event),
+      body: JSON.stringify({
+        ...event,
+        tickets: tickets.map(t => ({
+          name: t.name,
+          price: Number(t.price),
+          quantity: Number(t.quantity),
+          saleStart: t.saleStart,
+        })),
+      }),
     });
     const data = await res.json();
     if (res.ok) {
@@ -87,6 +115,75 @@ export default function EditEvent() {
           value={event.miniUrl || ''}
           onChange={e => handleChange('miniUrl', e.target.value)}
         />
+        {tickets.map((ticket, index) => (
+          <div key={index} className="mt-4">
+            <h3 className="font-semibold mb-2">Ticket Type {index + 1}</h3>
+            <input
+              className="border p-1 w-full mb-1"
+              value={ticket.name}
+              onChange={e => {
+                const updated = [...tickets];
+                updated[index].name = e.target.value;
+                setTickets(updated);
+              }}
+              placeholder="Ticket name"
+            />
+            <input
+              type="number"
+              className="border p-1 w-full mb-1"
+              value={ticket.price}
+              onChange={e => {
+                const updated = [...tickets];
+                updated[index].price = e.target.value;
+                setTickets(updated);
+              }}
+              placeholder="Price"
+            />
+            <input
+              type="number"
+              className="border p-1 w-full mb-1"
+              value={ticket.quantity}
+              onChange={e => {
+                const updated = [...tickets];
+                updated[index].quantity = e.target.value;
+                setTickets(updated);
+              }}
+              placeholder="Quantity"
+            />
+            <input
+              type="date"
+              className="border p-1 w-full mb-1"
+              value={ticket.saleStart}
+              onChange={e => {
+                const updated = [...tickets];
+                updated[index].saleStart = e.target.value;
+                setTickets(updated);
+              }}
+              placeholder="Sale start"
+            />
+            {tickets.length > 1 && (
+              <button
+                type="button"
+                className="text-sm text-red-500 mb-4"
+                onClick={() => setTickets(tickets.filter((_, i) => i !== index))}
+              >
+                Remove ticket type
+              </button>
+            )}
+          </div>
+        ))}
+        <button
+          type="button"
+          className="text-sm text-blue-500 mb-4"
+          onClick={() =>
+            setTickets([
+              ...tickets,
+              { name: '', price: '', quantity: '', saleStart: '' },
+            ])
+          }
+        >
+          Add ticket type
+        </button>
         <button type="submit" className="bg-blue-500 text-white px-2 py-1 rounded">
           Guardar
         </button>


### PR DESCRIPTION
## Summary
- Include ticket types in event API GET responses and validate ticket edits
- Support updating ticket types alongside event details
- Add ticket type management UI to the event edit page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f481e76c833397d2f8ffed0f252b