### PR TITLE
Add Vercel Speed Insights integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react-dom": "latest",
     "@prisma/client": "latest",
     "prisma": "latest",
-    "bcryptjs": "latest"
+    "bcryptjs": "latest",
+    "@vercel/speed-insights": "latest"
   },
   "devDependencies": {
     "typescript": "latest",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 import TopBar from '../components/TopBar';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -9,6 +10,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <div className="pt-16">
         <Component {...pageProps} />
       </div>
+      <SpeedInsights />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add @vercel/speed-insights dependency
- integrate SpeedInsights component into the Next.js app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f98e3e9c8333832dd015b2c1fcf6