### PR TITLE
List events with search and purchase form

### DIFF
--- a/src/pages/buy/[id].tsx
+++ b/src/pages/buy/[id].tsx
@@ -1,0 +1,70 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+interface Event {
+  id: number;
+  name: string;
+  posterUrl?: string;
+  date?: string;
+}
+
+export default function BuyEvent() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [event, setEvent] = useState<Event | null>(null);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [quantity, setQuantity] = useState(1);
+
+  useEffect(() => {
+    if (typeof id === 'string') {
+      fetch(`/api/events?id=${id}`)
+        .then(res => res.json())
+        .then(setEvent)
+        .catch(() => setEvent(null));
+    }
+  }, [id]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert('Compra enviada');
+  };
+
+  if (!event) {
+    return <div className="pt-20 max-w-md mx-auto">Cargando...</div>;
+  }
+
+  return (
+    <div className="pt-20 max-w-md mx-auto px-4">
+      <h1 className="text-2xl font-bold mb-4">Compra de {event.name}</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Nombre"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          type="email"
+          className="border p-2 w-full"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="number"
+          min={1}
+          className="border p-2 w-full"
+          value={quantity}
+          onChange={e => setQuantity(Number(e.target.value))}
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Comprar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import EventSlider, { Event } from '../components/EventSlider';
 
 export default function Home() {
   const [events, setEvents] = useState<Event[]>([]);
+  const [search, setSearch] = useState('');
 
   useEffect(() => {
     fetch('/api/events')
@@ -10,6 +12,10 @@ export default function Home() {
       .then(setEvents)
       .catch(() => setEvents([]));
   }, []);
+
+  const filteredEvents = events.filter(ev =>
+    ev.name.toLowerCase().includes(search.toLowerCase())
+  );
 
   return (
     <>
@@ -28,6 +34,35 @@ export default function Home() {
       </section>
 
       <EventSlider events={events} />
+
+      <section className="max-w-4xl mx-auto px-4">
+        <h2 className="text-2xl font-bold mb-4">Eventos</h2>
+        <input
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Buscar por nombre"
+          className="border p-2 w-full mb-4"
+        />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {filteredEvents.map(ev => (
+            <Link
+              key={ev.id}
+              href={`/buy/${ev.id}`}
+              className="border rounded p-4 hover:shadow cursor-pointer"
+            >
+              {ev.posterUrl && (
+                <img
+                  src={ev.posterUrl}
+                  alt={ev.name}
+                  className="w-full h-48 object-cover mb-2"
+                />
+              )}
+              <h3 className="text-lg font-semibold">{ev.name}</h3>
+            </Link>
+          ))}
+        </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add event listing with search on home page
- create purchase form page for events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4faebd22c8333977fd56a45a66fa5