### PR TITLE
Implement ticket purchase flow and API

### DIFF
--- a/src/pages/api/tickets.ts
+++ b/src/pages/api/tickets.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { randomUUID } from 'crypto';
+import { prisma } from '../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { eventId, email, quantity } = req.body;
+
+    if (typeof eventId !== 'number' || typeof quantity !== 'number' || quantity < 1) {
+      return res.status(400).json({ message: 'Invalid payload' });
+    }
+
+    const event = await prisma.event.findUnique({
+      where: { id: eventId },
+      include: { ticketTypes: { include: { _count: { select: { tickets: true } } } } },
+    });
+
+    if (!event || event.ticketTypes.length === 0) {
+      return res.status(404).json({ message: 'Event not found' });
+    }
+
+    const ticketType = event.ticketTypes[0];
+    const available = ticketType.quantity - ticketType._count.tickets;
+    if (quantity > available) {
+      return res.status(400).json({ message: 'Not enough tickets available' });
+    }
+
+    const data = Array.from({ length: quantity }).map(() => ({
+      ticketTypeId: ticketType.id,
+      email,
+      qrHash: randomUUID(),
+    }));
+
+    await prisma.ticket.createMany({ data });
+    return res.status(200).json({ message: 'Tickets created' });
+  }
+
+  return res.status(405).end();
+}

--- a/src/pages/buy/[id].tsx
+++ b/src/pages/buy/[id].tsx
@@ -25,9 +25,30 @@ export default function BuyEvent() {
     }
   }, [id]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    alert('Compra enviada');
+    if (typeof id !== 'string') return;
+
+    const res = await fetch('/api/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventId: Number(id),
+        name,
+        email,
+        quantity,
+      }),
+    });
+
+    if (res.ok) {
+      alert('Compra enviada');
+      setName('');
+      setEmail('');
+      setQuantity(1);
+    } else {
+      const data = await res.json().catch(() => null);
+      alert(data?.message || 'Error al procesar la compra');
+    }
   };
 
   if (!event) {


### PR DESCRIPTION
## Summary
- Allow buy page to submit ticket purchases
- Add `/api/tickets` endpoint to generate ticket records

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6615677c48333baa530a93d486612