### PR TITLE
Add Prisma binary target for rhel deployments

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,7 @@ datasource db {
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 model User {


### PR DESCRIPTION
## Summary
- ensure the generated Prisma client bundles the rhel-openssl-3.0.x engine for serverless deployments

## Testing
- npx prisma generate *(fails: unable to download Prisma engine binaries in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6903d1bdcd408333bbdcda4df7b628fa